### PR TITLE
Update start-qfs.sh

### DIFF
--- a/qfs/sbin/start-qfs.sh
+++ b/qfs/sbin/start-qfs.sh
@@ -89,90 +89,37 @@ function remote_command_eval ()
     RESULTS=$(ssh -l ${2} ${1} "${3}")
 }
 
-this="${BASH_SOURCE-$0}"
+this="${BASH_SOURCE:-$0}"
 bin=$(cd -P -- "$(dirname -- "${this}")" >/dev/null && pwd -P)
 
-if ! [[ -n "${NOHUP_CMD}" ]]; then
-	NOHUP_CMD="/usr/bin/nohup"
-fi
-
-if ! [[ -n "${QFS_HOME}" ]]; then
-        QFS_HOME="/usr/local/qfs"
-fi
-
-if ! [[ -n "${QFS_CONF_DIR}" ]]; then
-	QFS_CONF_DIR="${QFS_HOME}/conf"
-fi
-
+NOHUP_CMD=${NOHUP_CMD:-"/usr/bin/nohup"}
+QFS_HOME=${QFS_HOME:-"/usr/local/qfs"}
+QFS_CONF_DIR=${QFS_CONF_DIR:-"${QFS_HOME}/conf"}
 
 if [[ -f "${QFS_CONF_DIR}/qfs-env.sh" ]]; then
 	if [ "$START_QFS_SH_DEBUG" = true ]; then
 		echo "Sourcing environment variables from ${QFS_CONF_DIR}/qfs-env.sh"
     fi
-    . "${QFS_CONF_DIR}/qfs-env.sh"
+    source "${QFS_CONF_DIR}/qfs-env.sh"
 fi
 
 #
 # set needed environment variables if not set already
 #
-
-if ! [[ -n "${QFS_USER}" ]]; then
-	QFS_USER=$USER
-fi
-
-if ! [[ -n "${METASERVER_HOST_IP}" ]]; then
-	METASERVER_HOST_IP="localhost"
-fi
-
-if ! [[ -n "${QFS_BIN_DIR}" ]]; then
-	QFS_BIN_DIR="${QFS_HOME}/bin"
-fi
-
-if ! [[ -n "${QFS_LOGS_DIR}" ]]; then
-	QFS_LOGS_DIR="${QFS_HOME}/logs"
-fi
-
-
-if ! [[ -n "${METASERVER_CONF_FILENAME}" ]]; then
-	METASERVER_CONF_FILENAME="Metaserver.prp"
-fi
-
-if ! [[ -n "${CHUNKSERVER_CONF_FILENAME}" ]]; then
-	CHUNKSERVER_CONF_FILENAME="Chunkserver.prp"
-fi
-
-if ! [[ -n "${METASERVER_WEBUI_CONF_FILENAME}" ]]; then
-	METASERVER_WEBUI_CONF_FILENAME="webUI.cfg"
-fi
-
-if ! [[ -n "${METASERVER_LOG_FILENAME}" ]]; then
-	METASERVER_LOG_FILENAME="metaserver.log"
-fi
-
-if ! [[ -n "${CHUNKSERVER_LOG_FILENAME}" ]]; then
-	CHUNKSERVER_LOG_FILENAME="chunkserver.log"
-fi
-
-if ! [[ -n "${WEBUI_LOG_FILENAME}" ]]; then
-	WEBUI_LOG_FILENAME="qfsWebUI.log"
-fi
-
-if ! [[ -n "${METASERVER_LOG_FILEPATH}" ]]; then
-	METASERVER_LOG_FILEPATH="${QFS_LOGS_DIR}/${METASERVER_LOG_FILENAME}"
-fi
-
-if ! [[ -n "${CHUNKSERVER_LOG_FILEPATH}" ]]; then
-	CHUNKSERVER_LOG_FILEPATH="${QFS_LOGS_DIR}/${CHUNKSERVER_LOG_FILENAME}"
-fi
-
-
-if ! [[ -n "${QFS_METASERVER_START_CMD}" ]]; then
-	QFS_METASERVER_START_CMD="${QFS_BIN_DIR}/metaserver ${QFS_CONF_DIR}/${METASERVER_CONF_FILENAME}"
-fi
-
-if ! [[ -n "${QFS_CHUNKSERVER_START_CMD}" ]]; then
-	QFS_CHUNKSERVER_START_CMD="${QFS_BIN_DIR}/chunkserver ${QFS_CONF_DIR}/${CHUNKSERVER_CONF_FILENAME}"
-fi
+QFS_USER=${QFS_USER:-$USER}
+METASERVER_HOST_IP=${METASERVER_HOST_IP:-"localhost"}
+QFS_BIN_DIR=${QFS_BIN_DIR:-"${QFS_HOME}/bin"}
+QFS_LOGS_DIR=${QFS_LOGS_DIR:-"${QFS_HOME}/logs"}
+METASERVER_CONF_FILENAME=${METASERVER_CONF_FILENAME:-"Metaserver.prp"}
+CHUNKSERVER_CONF_FILENAME=${CHUNKSERVER_CONF_FILENAME:-"Chunkserver.prp"}
+METASERVER_WEBUI_CONF_FILENAME=${METASERVER_WEBUI_CONF_FILENAME:-"webUI.cfg"}
+METASERVER_LOG_FILENAME=${METASERVER_LOG_FILENAME:-"metaserver.log"}
+CHUNKSERVER_LOG_FILENAME=${CHUNKSERVER_LOG_FILENAME:-"chunkserver.log"}
+WEBUI_LOG_FILENAME=${WEBUI_LOG_FILENAME:-"qfsWebUI.log"}
+METASERVER_LOG_FILEPATH=${METASERVER_LOG_FILEPATH:-"${QFS_LOGS_DIR}/${METASERVER_LOG_FILENAME}"}
+CHUNKSERVER_LOG_FILEPATH=${CHUNKSERVER_LOG_FILEPATH:-"${QFS_LOGS_DIR}/${CHUNKSERVER_LOG_FILENAME}"}
+QFS_METASERVER_START_CMD=${QFS_METASERVER_START_CMD:-"${QFS_BIN_DIR}/metaserver ${QFS_CONF_DIR}/${METASERVER_CONF_FILENAME}"}
+QFS_CHUNKSERVER_START_CMD=${QFS_CHUNKSERVER_START_CMD:-"${QFS_BIN_DIR}/chunkserver ${QFS_CONF_DIR}/${CHUNKSERVER_CONF_FILENAME}"}
 
 #
 # Start MetaServer
@@ -185,7 +132,7 @@ if [ $? -eq 0 ]; then
 	echo "Meta Server started."
 else
 	echo "Meta Server failed to launch. Aborting!"
-	return
+	exit 1
 fi
 
 #
@@ -224,4 +171,5 @@ if [ $? -eq 0 ]; then
 	echo "Meta Server Web UI started."
 else
 	echo "Meta Server Web UI failed to launch."
+	exit 1
 fi


### PR DESCRIPTION
Added in the use of BASH parameter expansion syntax to set defaults, continued for it's use at line 92. Docs here: http://tldp.org/LDP/abs/html/parameter-substitution.html

Additionally allowed for error cases to exit non-zero for some insight into errors in launches.
